### PR TITLE
Fix NPEs in SQL Next and Contains

### DIFF
--- a/graph/sql/all_iterator.go
+++ b/graph/sql/all_iterator.go
@@ -131,6 +131,9 @@ func (it *AllIterator) Next() bool {
 	graph.NextLogIn(it)
 	if it.cursor == nil {
 		it.makeCursor()
+		if it.cursor == nil {
+			return false
+		}
 	}
 	if !it.cursor.Next() {
 		glog.V(4).Infoln("sql: No next")

--- a/graph/sql/sql_iterator.go
+++ b/graph/sql/sql_iterator.go
@@ -151,6 +151,11 @@ func (it *SQLIterator) Next() bool {
 	graph.NextLogIn(it)
 	if it.cursor == nil {
 		err = it.makeCursor(true, nil)
+		if err != nil {
+			glog.Errorf("Couldn't make query: %v", err)
+			it.err = err
+			return false
+		}
 		it.cols, err = it.cursor.Columns()
 		if err != nil {
 			glog.Errorf("Couldn't get columns")
@@ -226,7 +231,9 @@ func (it *SQLIterator) Contains(v graph.Value) bool {
 	if err != nil {
 		glog.Errorf("Couldn't make query: %v", err)
 		it.err = err
-		it.cursor.Close()
+		if it.cursor != nil {
+			it.cursor.Close()
+		}
 		return false
 	}
 	it.cols, err = it.cursor.Columns()


### PR DESCRIPTION
Trace for `Next`
```
E0825 16:31:29.241120 26925 sql_iterator.go:301] Couldn't get cursor from SQL database: pq: remaining connection slots are reserved for non-replication superuser connections
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x7ab49e]

goroutine 2876 [running]:
database/sql.(*Rows).Columns(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/ubuntu/.gvm/gos/go1.4.2/src/database/sql/sql.go:1613 +0x5e
github.com/barakmich/cayley/graph/sql.(*SQLIterator).Next(0xc208bb9170, 0x7fc2f391b888)
	/home/ubuntu/src/github.com/barakmich/cayley/graph/sql/sql_iterator.go:154 +0xe7
github.com/barakmich/cayley/graph.Next(0x7fc2f391b888, 0xc208bb9170, 0xc208bb9170)
	/home/ubuntu/src/github.com/barakmich/cayley/graph/iterator.go:190 +0x74
```

Same issue in `Contains`

That is basically the same as the https://github.com/Quentin-M/cayley/commit/1156dfbd141bb8c31a8067b4cd09f85b4daee897 and https://github.com/barakmich/cayley/issues/6 submitted on Jul 21, but updated.

*Contributor License Agreement* signed.