### PR TITLE
Make the SQL connection fail-fast

### DIFF
--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -44,6 +44,13 @@ func connectSQLTables(addr string, _ graph.Options) (*sql.DB, error) {
 		glog.Errorf("Couldn't open database at %s: %#v", addr, err)
 		return nil, err
 	}
+	// "Open may just validate its arguments without creating a connection to the database."
+	// "To verify that the data source name is valid, call Ping."
+	// Source: http://golang.org/pkg/database/sql/#Open
+	if err := conn.Ping(); err != nil {
+		glog.Errorf("Couldn't open database at %s: %#v", addr, err)
+		return nil, err
+	}
 	return conn, nil
 }
 


### PR DESCRIPTION
Using `sql.Open` is not enough to determine if a SQL connection is valid. We should not let the user think that the connection has been successfully opened if it is not the case.

This commit adds a `conn.Ping` call and a test as suggested in http://golang.org/pkg/database/sql/#Open in the connection function to determine ASAP if the everything is actually okay.

_Contributor License Agreement_ signed.
